### PR TITLE
Added image assets to uploaded artifacts in github actions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -59,7 +59,9 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
-          path: "./OCAExplorer/dist"
+          path: |
+            "./OCAExplorer/dist"
+            "./OCAExplorer/assets"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
This should resolve the missing image asset in #52 . I haven't managed to test this yet. Alternatively I can simply have the npm scripts copy the directory themselves to the `dist`. To me this seems like a cleaner solution.