### PR TITLE
Skip at start of the tutorial prevents 2nd half from playing

### DIFF
--- a/OCAExplorer/src/App.tsx
+++ b/OCAExplorer/src/App.tsx
@@ -1,5 +1,5 @@
 import { Container, Typography } from "@mui/material";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useMemo, useEffect} from "react";
 import Form from "./components/Form";
 import OverlayForm from "./components/OverlayForm";
 import Header from "./components/Header";
@@ -21,17 +21,16 @@ function App() {
   }>({ overlay: undefined, record: undefined });
 
   // Track if we should skip the rest of the demo.
-  // Default value should be set based on the stored token in local storage
   const [skipDemo, setSkipDemo] = useState<boolean>(localStorage.getItem('OCAExplorerSeenDemo') != null);
 
-  const forceSkipDemo = () => {
-    if (skipDemo == false) {
-        localStorage.setItem('OCAExplorerSeenDemo', 'true');
+  useEffect( () => {
+    // update localStorage to reflect the skipDemo state
+    if (skipDemo == true) {
+      localStorage.setItem('OCAExplorerSeenDemo', 'true');
     }
-    setSkipDemo(true)
-  }
+  }, [skipDemo])
 
-  const [runDemo, setRunDemo] = skipDemo ? useState<DemoState>("NotRunning") : useState<DemoState>("RunningIntro")
+  const [runDemo, setRunDemo] = skipDemo ? useState<DemoState>(DemoState.NotRunning) : useState<DemoState>(DemoState.RunningIntro)
 
   const handleOverlayData = useCallback(
     (overlayData: {
@@ -48,8 +47,8 @@ function App() {
       });
       setOverlayData({ ...overlayData, record });
       if (!skipDemo) {
-        setRunDemo("RunningBranding");
-        forceSkipDemo()
+        setRunDemo(DemoState.RunningBranding);
+        setSkipDemo(true)
       }
     } ,
       [skipDemo]
@@ -60,14 +59,14 @@ function App() {
       <CssBaseline />
       <ThemeProvider theme={theme}>
         {/* If the overlay is displayed play through all steps if not only play the intro steps */}
-        <Header callback={ () => (overlayData?.overlay ? setRunDemo("RunningAll") : setRunDemo("RunningIntro"))}/>
+        <Header callback={ () => (overlayData?.overlay ? setRunDemo(DemoState.RunningAll) : setRunDemo(DemoState.RunningIntro))}/>
         <div className="App">
           <Demo runDemo={runDemo}
                 theme={theme}
-                resetFunc={ () => setRunDemo("NotRunning") }
+                resetFunc={ () => setRunDemo(DemoState.NotRunning) }
                 skipFunc={ () => {
-                  setRunDemo("NotRunning")
-                  forceSkipDemo()
+                  setSkipDemo(true)
+                  setRunDemo(DemoState.NotRunning)
                 }}/>
           <Container>
             <Form onOverlayData={handleOverlayData} />

--- a/OCAExplorer/src/App.tsx
+++ b/OCAExplorer/src/App.tsx
@@ -21,17 +21,17 @@ function App() {
   }>({ overlay: undefined, record: undefined });
 
   // Track if we should skip the rest of the demo.
-  const [runDemo, setRunDemo] = useState<DemoState>(
+  const [demoState, setDemoState] = useState<DemoState>(
     localStorage.getItem('OCAExplorerSeenDemo') != null
-    ? DemoState.SkipDemo : DemoState.RunningIntro
+    ? DemoState.SeenDemo : DemoState.RunningIntro
   )
 
   useEffect( () => {
     // update localStorage to reflect the skipDemo state
-    if (runDemo == DemoState.SkipDemo) {
+    if (demoState == DemoState.SeenDemo) {
       localStorage.setItem('OCAExplorerSeenDemo', 'true');
     }
-  }, [ runDemo ]);
+  }, [ demoState ]);
 
   const handleOverlayData = useCallback(
     (overlayData: {
@@ -47,11 +47,11 @@ function App() {
         ),
       });
       setOverlayData({ ...overlayData, record });
-      if (runDemo != DemoState.SkipDemo) {
-        setRunDemo(DemoState.RunningBranding);
+      if (demoState != DemoState.SeenDemo) {
+        setDemoState(DemoState.RunningBranding);
       }
     } ,
-      [ runDemo ]
+      [ demoState ]
   );
 
   return (
@@ -59,21 +59,21 @@ function App() {
       <CssBaseline />
       <ThemeProvider theme={theme}>
         {/* If the overlay is displayed play through all steps if not only play the intro steps */}
-        <Header callback={ () => setRunDemo(
+        <Header callback={ () => setDemoState(
           overlayData?.overlay
           ? DemoState.RunningAll
           : DemoState.RunningIntro
         )}/>
         <div className="App">
-          <Demo runDemo={runDemo}
+          <Demo runDemo={demoState}
                 theme={theme}
-                resetFunc={ () => setRunDemo(
+                resetFunc={ () => setDemoState(
                   overlayData?.overlay
-                  ? DemoState.SkipDemo
+                  ? DemoState.SeenDemo
                   : DemoState.NotRunning
                 )
                 }
-                skipFunc={ () => setRunDemo(DemoState.SkipDemo) }/>
+                skipFunc={ () => setDemoState(DemoState.SeenDemo) }/>
           <Container>
             <Form onOverlayData={handleOverlayData} />
             {overlayData?.overlay && (

--- a/OCAExplorer/src/App.tsx
+++ b/OCAExplorer/src/App.tsx
@@ -21,16 +21,16 @@ function App() {
   }>({ overlay: undefined, record: undefined });
 
   // Track if we should skip the rest of the demo.
+  const initStore = localStorage.getItem('OCAExplorerSeenDemo')
   const [demoState, setDemoState] = useState<DemoState>(
-    localStorage.getItem('OCAExplorerSeenDemo') != null
-    ? DemoState.SeenDemo : DemoState.RunningIntro
+    initStore != null && initStore != DemoState.PausedDemo.toString()
+    ? parseInt(initStore)
+    : DemoState.RunningIntro
   )
 
   useEffect( () => {
     // update localStorage to reflect the skipDemo state
-    if (demoState == DemoState.SeenDemo) {
-      localStorage.setItem('OCAExplorerSeenDemo', 'true');
-    }
+    localStorage.setItem('OCAExplorerSeenDemo', demoState.toString());
   }, [ demoState ]);
 
   const handleOverlayData = useCallback(
@@ -70,7 +70,7 @@ function App() {
                 resetFunc={ () => setDemoState(
                   overlayData?.overlay
                   ? DemoState.SeenDemo
-                  : DemoState.NotRunning
+                  : DemoState.PausedDemo
                 )
                 }
                 skipFunc={ () => setDemoState(DemoState.SeenDemo) }/>

--- a/OCAExplorer/src/App.tsx
+++ b/OCAExplorer/src/App.tsx
@@ -17,7 +17,7 @@ import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 const setNewUserCookie = () => {
     document.cookie = 'OCAExplorerSeenDemo=true; path=/;';
 }
-const seenDemo: string | undefined = document.cookie.split('; ').find((c) => c.split("=")[0] == 'OCAExplorerSeenDemo');
+const seenDemo: () => string | undefined = () => document.cookie.split('; ').find((c) => c.split("=")[0] == 'OCAExplorerSeenDemo');
 
 function App() {
   const [overlayData, setOverlayData] = useState<{
@@ -41,7 +41,7 @@ function App() {
         ),
       });
         setOverlayData({ ...overlayData, record });
-    if ( !seenDemo ){
+    if ( !seenDemo() ){
       setRunDemo("RunningBranding");
       setNewUserCookie()
     }
@@ -49,7 +49,7 @@ function App() {
       []
   );
 
-      const [runDemo, setRunDemo] = seenDemo ? useState<DemoState>("NotRunning") : useState<DemoState>("RunningIntro")
+      const [runDemo, setRunDemo] = seenDemo() ? useState<DemoState>("NotRunning") : useState<DemoState>("RunningIntro")
 
   return (
       <StyledEngineProvider injectFirst>
@@ -58,7 +58,13 @@ function App() {
         {/* If the overlay is displayed play through all steps if not only play the intro steps */}
         <Header callback={ () => (overlayData?.overlay ? setRunDemo("RunningAll") : setRunDemo("RunningIntro"))}/>
           <div className="App">
-            <Demo runDemo={runDemo} theme={theme} resetFunc={ () => setRunDemo("NotRunning") }/>
+              <Demo runDemo={runDemo}
+                    theme={theme}
+                    resetFunc={ () => setRunDemo("NotRunning") }
+                    skipFunc={ () => {
+                      setRunDemo("NotRunning")
+                      setNewUserCookie()
+                    }}/>
             <Container>
               <Form onOverlayData={handleOverlayData} />
               {overlayData?.overlay && (

--- a/OCAExplorer/src/components/Demo.tsx
+++ b/OCAExplorer/src/components/Demo.tsx
@@ -95,7 +95,7 @@ export enum DemoState{
     RunningIntro,
     RunningBranding,
     RunningAll,
-    SkipDemo,
+    SeenDemo,
 }
 
 export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoState, theme: Theme, resetFunc: () => void, skipFunc: () => void  }) {

--- a/OCAExplorer/src/components/Demo.tsx
+++ b/OCAExplorer/src/components/Demo.tsx
@@ -91,10 +91,10 @@ const demoStates = {
 }
 
 export enum DemoState{
-    NotRunning,
     RunningIntro,
     RunningBranding,
     RunningAll,
+    PausedDemo,
     SeenDemo,
 }
 
@@ -137,6 +137,6 @@ export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoStat
                zIndex: 1000,
              }
 	   }}
-	   run={runDemo != DemoState.NotRunning}
+           run={(runDemo != DemoState.PausedDemo) && (runDemo != DemoState.SeenDemo)}
          />
 }

--- a/OCAExplorer/src/components/Demo.tsx
+++ b/OCAExplorer/src/components/Demo.tsx
@@ -95,6 +95,7 @@ export enum DemoState{
     RunningIntro,
     RunningBranding,
     RunningAll,
+    SkipDemo,
 }
 
 export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoState, theme: Theme, resetFunc: () => void, skipFunc: () => void  }) {

--- a/OCAExplorer/src/components/Demo.tsx
+++ b/OCAExplorer/src/components/Demo.tsx
@@ -90,7 +90,12 @@ const demoStates = {
   }]
 }
 
-export type DemoState = "NotRunning" | "RunningIntro" | "RunningBranding" | "RunningAll"
+export enum DemoState{
+    NotRunning,
+    RunningIntro,
+    RunningBranding,
+    RunningAll,
+}
 
 export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoState, theme: Theme, resetFunc: () => void, skipFunc: () => void  }) {
   const handleJoyrideCallback = (data: any) => {
@@ -102,13 +107,13 @@ export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoStat
       skipFunc()
     }
   }
-  const steps = () => {
+    const steps = () => {
     switch (runDemo){
-      case "RunningIntro":
+      case DemoState.RunningIntro:
         return demoStates.introSteps
-      case "RunningBranding":
+      case DemoState.RunningBranding:
         return demoStates.brandingSteps
-      case "RunningAll":
+      case DemoState.RunningAll:
         return [...demoStates.introSteps, ...demoStates.brandingSteps]
       default:
         return []
@@ -131,6 +136,6 @@ export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoStat
                zIndex: 1000,
              }
 	   }}
-	   run={runDemo != "NotRunning"}
+	   run={runDemo != DemoState.NotRunning}
          />
 }

--- a/OCAExplorer/src/components/Demo.tsx
+++ b/OCAExplorer/src/components/Demo.tsx
@@ -92,13 +92,14 @@ const demoStates = {
 
 export type DemoState = "NotRunning" | "RunningIntro" | "RunningBranding" | "RunningAll"
 
-export function Demo({runDemo, theme, resetFunc }: {runDemo: DemoState, theme: Theme, resetFunc: () => void }) {
+export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoState, theme: Theme, resetFunc: () => void, skipFunc: () => void  }) {
   const handleJoyrideCallback = (data: any) => {
     const { status, type } = data;
-    const finishedStatuses: string[] = [STATUS.FINISHED, STATUS.SKIPPED];
 
-    if (finishedStatuses.includes(status)) {
+    if (status == STATUS.FINISHED) {
       resetFunc()
+    } else if (status == STATUS.SKIPPED){
+      skipFunc()
     }
   }
   const steps = () => {


### PR DESCRIPTION
This PR resolves issue #61 when `skip` is selected all automatic tutorial playback is stopped unless the `info` icon is selected.