### PR TITLE
Esc now skips and Last->End resolving #63 and #64

### DIFF
--- a/OCAExplorer/src/components/Demo.tsx
+++ b/OCAExplorer/src/components/Demo.tsx
@@ -1,5 +1,5 @@
 import { Typography, Link } from "@mui/material";
-import Joyride, {STATUS} from 'react-joyride';
+import Joyride, {STATUS, ACTIONS } from 'react-joyride';
 import { Theme } from '@mui/material/styles';
 
 const demoStates = {
@@ -100,11 +100,10 @@ export enum DemoState{
 
 export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoState, theme: Theme, resetFunc: () => void, skipFunc: () => void  }) {
   const handleJoyrideCallback = (data: any) => {
-    const { status, type } = data;
-
+    const { action, status, type } = data;
     if (status == STATUS.FINISHED) {
       resetFunc()
-    } else if (status == STATUS.SKIPPED){
+    } else if ((status == STATUS.SKIPPED) || (action == ACTIONS.CLOSE)){
       skipFunc()
     }
   }
@@ -123,6 +122,13 @@ export function Demo({runDemo, theme, resetFunc, skipFunc, }: {runDemo: DemoStat
   return <Joyride
 	   callback={handleJoyrideCallback}
 	   continuous
+           locale={{ back: 'Back',
+                     close: 'Close',
+                     last: 'End',
+                     next: 'Next',
+                     open: 'Open the dialog',
+                     skip: 'Skip'
+           }}
 	   hideCloseButton
 	   scrollToFirstStep
 	   showSkipButton


### PR DESCRIPTION
Since escape closes the window I added the action to skip the demo when escape is hit. I also reworded `Last` to end the demo to `End`. This should resolve both #63 and #64

![image](https://github.com/bcgov/aries-oca-bundles/assets/34443260/5340b44d-c270-4bea-902a-ca7096766be7)
