### PR TITLE
feat: added support for uploading images

### DIFF
--- a/OCAExplorer/src/components/ImageField.tsx
+++ b/OCAExplorer/src/components/ImageField.tsx
@@ -64,7 +64,10 @@ export default function ImageField({
         />
         <Button variant="text" component="label" size="small" disableElevation>
           <FileUpload/>
-          <input hidden type="file" id="myfile" name="myfile" onChange={handleImageChange}/>
+          <input hidden type="file" id="myfile" name="myfile" onChange={(e) => {
+            setWasFile(true)
+            handleImageChange(e)
+          }}/>
         </Button>
       </Box>
       { !validFile && <Alert severity="error">ERROR: This file does not seem to be a valid image</Alert>}

--- a/OCAExplorer/src/components/ImageField.tsx
+++ b/OCAExplorer/src/components/ImageField.tsx
@@ -1,6 +1,10 @@
-import { FileUpload } from "@mui/icons-material";
-import { Box, TextField, Button, Alert } from "@mui/material"
-import { useState, useEffect } from "react";
+import { FileUpload, FilterVintageOutlined } from "@mui/icons-material";
+import { Box, TextField, Button, Snackbar, Alert } from "@mui/material"
+import { useState, ReactNode } from "react";
+
+// The upper limit required to base64 encode a 1920x1080 PNG image based on testing.
+// Users should be necouraged to avoid PNGs if possible due to the added file size
+const MAX_IMAGE_SIZE = 1000000
 
 export default function ImageField({
   id, label,  value, textSetter
@@ -8,17 +12,17 @@ export default function ImageField({
   id?: any, label: string, value: string, textSetter: (e: any) => void
 }) {
 
-  /*
-     Since we only want to show the number of characters if the
-     content was set using a file
-   */
-  const [ wasFile, setWasFile ] = useState<boolean>(false)
-  const [ validFile, setValidFile ] = useState<boolean>(true)
+  enum FileStatus {
+    NoFile,
+    ValidFile,
+    InvalidImage,
+    FileTooLarge,
+  }
+  type FileState =  { status: FileStatus, value: String }
 
-  // Ensure that when the value is changed the new image is assumed to be valid
-  useEffect(() => {
-    setValidFile(true)
-  }, [value])
+  const [ file, setFile ] = useState<FileState>({status: FileStatus.NoFile, value: value})
+  const isError = (f: FileState) => f.status != FileStatus.ValidFile && f.status != FileStatus.NoFile
+
 
   const handleImageChange = (event: any) => {
     const file = event.target.files[0];
@@ -32,10 +36,17 @@ export default function ImageField({
       const image = new Image();
 
       // If invalid warn the user and do not update field
-      image.onerror = () => setValidFile(false);
+      image.onerror = () => setFile({status: FileStatus.InvalidImage, value: imageDataURL});
 
       // If valid image update text field with this data url
-      image.onload = () => textSetter(imageDataURL);
+      image.onload = () => {
+        if (imageDataURL.length < MAX_IMAGE_SIZE){
+          setFile({status: FileStatus.ValidFile, value: imageDataURL})
+          textSetter(imageDataURL)
+        } else {
+          setFile({status: FileStatus.FileTooLarge, value: imageDataURL});
+        }
+      }
 
       image.src = imageDataURL
     };
@@ -43,34 +54,55 @@ export default function ImageField({
     reader.readAsDataURL(file);
   }
 
+  // Used for generating a simple overridable error message
+  const errorMessage = (msg: ReactNode) =>
+    <Alert
+      action={
+        <Button onClick={() => {
+          setFile({
+            ...file,
+            status: FileStatus.ValidFile
+          })
+          textSetter(file.value)
+        }}> Proceed Anyways </Button>
+      }
+      severity="error">{msg}</Alert>;
+
   return (
     <div>
       <Box sx={{ display: "flex" }}>
         <TextField
           fullWidth
-          id={ id }
-          label={ label + (
-            wasFile
-            ? " (" + value.length + " characters long" + ")"
-            : ""
-          ) }
-          value={ value }
-          onChange={ (event) => {
-            setWasFile(false)
-            textSetter(event.target.value)
-          } }
           margin="dense"
           size="small"
+          id={ id }
+          error={ isError(file) }
+          value={ isError(file) ? "" : value }
+          label={ label + " (" + value.length + " characters long" + ")" }
+          onChange={ (event) => {
+            setFile({status: FileStatus.NoFile, value: event.target.value})
+            textSetter(event.target.value)
+          } }
         />
         <Button variant="text" component="label" size="small" disableElevation>
           <FileUpload/>
           <input hidden type="file" id="myfile" name="myfile" onChange={(e) => {
-            setWasFile(true)
             handleImageChange(e)
           }}/>
         </Button>
       </Box>
-      { !validFile && <Alert severity="error">ERROR: This file does not seem to be a valid image</Alert>}
+      <Snackbar
+        autoHideDuration={6000}
+        open={isError(file)}
+      >
+        {file.status == FileStatus.InvalidImage
+                     ? errorMessage(<>ERROR: This file does not seem to be a valid image. Are you sure you want to use this file?</>)
+                     : file.status == FileStatus.FileTooLarge
+                     ? errorMessage(<>ERROR: We recommend not using an image larger than {MAX_IMAGE_SIZE} characters after encoding. Are you sure you want to use this file?</>)
+                     : undefined
+        }
+      </Snackbar>
+
     </div>
   );
 }

--- a/OCAExplorer/src/components/ImageField.tsx
+++ b/OCAExplorer/src/components/ImageField.tsx
@@ -1,0 +1,73 @@
+import { FileUpload } from "@mui/icons-material";
+import { Box, TextField, Button, Alert } from "@mui/material"
+import { useState, useEffect } from "react";
+
+export default function ImageField({
+  id, label,  value, textSetter
+}: {
+  id?: any, label: string, value: string, textSetter: (e: any) => void
+}) {
+
+  /*
+     Since we only want to show the number of characters if the
+     content was set using a file
+   */
+  const [ wasFile, setWasFile ] = useState<boolean>(false)
+  const [ validFile, setValidFile ] = useState<boolean>(true)
+
+  // Ensure that when the value is changed the new image is assumed to be valid
+  useEffect(() => {
+    setValidFile(true)
+  }, [value])
+
+  const handleImageChange = (event: any) => {
+    const file = event.target.files[0];
+
+    const reader = new FileReader();
+
+    reader.onload = (e: any) => {
+      const imageDataURL: string = e.target.result;
+
+      // Image validation
+      const image = new Image();
+
+      // If invalid warn the user and do not update field
+      image.onerror = () => setValidFile(false);
+
+      // If valid image update text field with this data url
+      image.onload = () => textSetter(imageDataURL);
+
+      image.src = imageDataURL
+    };
+
+    reader.readAsDataURL(file);
+  }
+
+  return (
+    <div>
+      <Box sx={{ display: "flex" }}>
+        <TextField
+          fullWidth
+          id={ id }
+          label={ label + (
+            wasFile
+            ? " (" + value.length + " characters long" + ")"
+            : ""
+          ) }
+          value={ value }
+          onChange={ (event) => {
+            setWasFile(false)
+            textSetter(event.target.value)
+          } }
+          margin="dense"
+          size="small"
+        />
+        <Button variant="text" component="label" size="small" disableElevation>
+          <FileUpload/>
+          <input hidden type="file" id="myfile" name="myfile" onChange={handleImageChange}/>
+        </Button>
+      </Box>
+      { !validFile && <Alert severity="error">ERROR: This file does not seem to be a valid image</Alert>}
+    </div>
+  );
+}

--- a/OCAExplorer/src/components/OverlayBrandingForm.tsx
+++ b/OCAExplorer/src/components/OverlayBrandingForm.tsx
@@ -16,6 +16,7 @@ import {
 import { saveAs } from "file-saver";
 import BrandingOverlayDataFactory from "../services/OverlayBrandingDataFactory";
 import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import ImageField from "./ImageField";
 
 function OverlayBrandingForm({
   overlay,
@@ -47,51 +48,41 @@ function OverlayBrandingForm({
   return (
     <div id="overlay-bundle-branding-form">
       <div id="overlay-bundle-branding-form-fields">
-        <TextField
-          fullWidth
+        <ImageField
           id="logo"
           label="Logo"
-          value={branding?.logo ?? ""}
-          onChange={(e) => {
+          value={ branding?.logo ?? ""}
+          textSetter={(content: string) => (
             dispatch &&
             dispatch({
               type: ActionType.LOGO,
-              payload: { logo: e.target.value },
-            });
-          }}
-          margin="dense"
-          size="small"
-        />
-        <TextField
-          fullWidth
+              payload: { logo: content },
+            })
+          )} />
+        <ImageField
           id="background-image"
           label="Background Image"
           value={branding?.backgroundImage ?? ""}
-          onChange={(e) => {
+          textSetter={(f: string) => {
             dispatch &&
             dispatch({
               type: ActionType.BACKGROUND_IMAGE,
-              payload: { backgroundImage: e.target.value },
+              payload: { backgroundImage: f },
             });
           }}
-          margin="dense"
-          size="small"
         />
-        <TextField
-          fullWidth
+        <ImageField
           id="background-image-slice"
           label="Background Image Slice"
           value={branding?.backgroundImageSlice ?? ""}
-          onChange={(e) => {
+          textSetter={(content) => {
             dispatch &&
             dispatch({
               type: ActionType.BACKGROUND_IMAGE_SLICE,
-              payload: { backgroundImageSlice: e.target.value },
+              payload: { backgroundImageSlice: content },
             });
           }}
-          margin="dense"
-          size="small"
-        />
+          />
         <MuiColorInput
           fullWidth
           id="primary-background-color"

--- a/OCAExplorer/src/components/OverlayBrandingForm.tsx
+++ b/OCAExplorer/src/components/OverlayBrandingForm.tsx
@@ -63,11 +63,11 @@ function OverlayBrandingForm({
           id="background-image"
           label="Background Image"
           value={branding?.backgroundImage ?? ""}
-          textSetter={(f: string) => {
+          textSetter={(content: string) => {
             dispatch &&
             dispatch({
               type: ActionType.BACKGROUND_IMAGE,
-              payload: { backgroundImage: f },
+              payload: { backgroundImage: content },
             });
           }}
         />
@@ -82,7 +82,7 @@ function OverlayBrandingForm({
               payload: { backgroundImageSlice: content },
             });
           }}
-          />
+         />
         <MuiColorInput
           fullWidth
           id="primary-background-color"


### PR DESCRIPTION
This pull request resolves #36 by adding support for uploading images and converting them to a base64 encoded data url. 

# Overview
How OCAExplorer now looks with an example of a default url, an uploaded image, and it looks like when a pdf uploaded rather than an image.
![image](https://github.com/bcgov/aries-oca-bundles/assets/34443260/e0b6dc13-ec12-470c-a0c1-fe17cfa8ce8a)

# Changes 
When viewing an OCA bundle the inputs that accept an image will now display an upload icon.
![image](https://github.com/bcgov/aries-oca-bundles/assets/34443260/8c12e667-19d0-470c-a161-59cadb603d24)

When clicked an image can be uploaded and converted to a base 64 encoded data url.
![image](https://github.com/bcgov/aries-oca-bundles/assets/34443260/61e252bc-a7cd-42e8-b91f-86aaa4085701)

NOTE: The number of characters used in the data url is added to the description as requested in #36 

If a non image file is uploaded the following error is given and the encoded version of that file is not input.
![image](https://github.com/bcgov/aries-oca-bundles/assets/34443260/b51b9a72-9c21-4e9d-af7f-96761c60ef83)

And finally all of these changes are reflected when the final branding.json is downloaded

![image](https://github.com/bcgov/aries-oca-bundles/assets/34443260/047ee70b-b668-412b-ad56-c8963672553b)

