### PR TITLE
Fix image slice link (from bc-wallet-mobile) for student card bundle

### DIFF
--- a/OCABundles/schema/bcgov-digital-trust/student-card/OCABundle.json
+++ b/OCABundles/schema/bcgov-digital-trust/student-card/OCABundle.json
@@ -115,7 +115,7 @@
       },
       {
         "logo": "https://raw.githubusercontent.com/bcgov/aries-oca-bundles/main/OCABundles/schema/bcgov-digital-trust/student-card/best-bc-logo.png",
-        "background_image_slice": "https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image-slice.png",
+        "background_image_slice": "https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image-slice.jpg",
         "background_image": "https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image.jpg",
         "primary_background_color": "#32674e",
         "capture_base": "E75sopl65qnoZRwjQQ0FjWGemLlOXcXtanhScZ2CloJY",

--- a/OCABundles/schema/bcgov-digital-trust/student-card/branding.json
+++ b/OCABundles/schema/bcgov-digital-trust/student-card/branding.json
@@ -1,7 +1,7 @@
 [
   {
     "logo": "https://raw.githubusercontent.com/bcgov/aries-oca-bundles/main/OCABundles/schema/bcgov-digital-trust/student-card/best-bc-logo.png",
-    "background_image_slice": "https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image-slice.png",
+    "background_image_slice": "https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image-slice.jpg",
     "background_image": "https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image.jpg",
     "primary_background_color": "#32674e",
     "capture_base": "E75sopl65qnoZRwjQQ0FjWGemLlOXcXtanhScZ2CloJY",


### PR DESCRIPTION
The existing image link in the student card bundle for `background_image_slice`:
https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image-slice.png
currently is a 404.

It seems to have been changed at the source to a jpg. Update to the proper link:
https://raw.githubusercontent.com/bcgov/bc-wallet-mobile/main/app/src/assets/branding/best-bc-background-image-slice.jpg