### PR TITLE
chore: remove submodule

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,24 +32,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Checkout submodule dependency
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          repository: petridishdev/aries-mobile-agent-react-native
-          path: "./aries-bifold"
-          ref: feature/oca-package_attributes
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
           cache-dependency-path: "./OCAExplorer"
-      - name: Install submodule
-        run: cd './aries-bifold/packages/oca' && yarn install --immutable
-      - name: Build submodule
-        run: cd './aries-bifold/packages/oca' && yarn build
-      - name: Install dependencies
         run: cd './OCAExplorer' && yarn install --immutable
       - name: Build
         run: cd './OCAExplorer' && yarn build

--- a/OCAExplorer/package.json
+++ b/OCAExplorer/package.json
@@ -4,18 +4,16 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "install:dev": "yarn prepare:dev && yarn install",
-    "prepare:dev": "cd ${PWD}/../aries-bifold && git checkout feature/oca-package && cd ${PWD}/packages/oca && yarn install && yarn build",
     "dev": "vite",
     "build": "tsc && vite build --base=./",
     "preview": "vite preview",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@aries-bifold/oca": "file:../aries-bifold/packages/oca",
     "@aries-framework/core": "^0.3.3",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
+    "@hyperledger/aries-oca": "^1.0.0-alpha.7",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.11.14",
     "csv-parse": "^5.3.10",

--- a/OCAExplorer/src/App.tsx
+++ b/OCAExplorer/src/App.tsx
@@ -6,7 +6,7 @@ import OverlayForm from "./components/OverlayForm";
 import Header from "./components/Header";
 import { Demo, DemoState } from "./components/Demo";
 import theme from "./theme";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 import {
   CredentialExchangeRecord,
   CredentialPreviewAttribute,

--- a/OCAExplorer/src/components/AttributeLabel.tsx
+++ b/OCAExplorer/src/components/AttributeLabel.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from "react";
-import { DisplayAttribute } from "@aries-bifold/oca/build/formatters/Credential";
+import { DisplayAttribute } from "@hyperledger/aries-oca/build/formatters/Credential";
 import startCase from "lodash.startcase";
 import { Text } from "react-native";
 

--- a/OCAExplorer/src/components/AttributeValue.tsx
+++ b/OCAExplorer/src/components/AttributeValue.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from "react";
 import { Image, Text } from "react-native";
-import { DisplayAttribute } from "@aries-bifold/oca/build/formatters/Credential";
+import { DisplayAttribute } from "@hyperledger/aries-oca/build/formatters/Credential";
 
 function AttributeValue({
   attribute,

--- a/OCAExplorer/src/components/CredentialCard.tsx
+++ b/OCAExplorer/src/components/CredentialCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 import CredentialCard10 from "./CredentialCard10";
 import { CredentialExchangeRecord } from "@aries-framework/core";
 

--- a/OCAExplorer/src/components/CredentialCard10.tsx
+++ b/OCAExplorer/src/components/CredentialCard10.tsx
@@ -1,15 +1,11 @@
 import React, { CSSProperties } from "react";
 import { Text, View, Image, ImageBackground } from "react-native";
 import { useBranding } from "../contexts/Branding";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
-import { textColorForBackground } from "@aries-bifold/oca/build/utils/color";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
+import { textColorForBackground } from "@hyperledger/aries-oca/build/utils/color";
 import { CredentialExchangeRecord } from "@aries-framework/core";
 import { useMemo, useState } from "react";
-import {
-  CredentialFormatter,
-  DisplayAttribute,
-  LocalizedCredential,
-} from "@aries-bifold/oca/build/formatters/Credential";
+import { CredentialFormatter, DisplayAttribute, LocalizedCredential } from "@hyperledger/aries-oca/build/formatters/Credential";
 import AttributeLabel from "./AttributeLabel";
 import AttributeValue from "./AttributeValue";
 

--- a/OCAExplorer/src/components/CredentialDetail.tsx
+++ b/OCAExplorer/src/components/CredentialDetail.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 import CredentialDetail10 from "./CredentialDetail10";
 import { CredentialExchangeRecord } from "@aries-framework/core";
 

--- a/OCAExplorer/src/components/CredentialDetail10.tsx
+++ b/OCAExplorer/src/components/CredentialDetail10.tsx
@@ -1,15 +1,15 @@
 import React, { CSSProperties } from "react";
 import { View, Image, ImageBackground, Text, FlatList } from "react-native";
 import { useBranding } from "../contexts/Branding";
-import { textColorForBackground } from "@aries-bifold/oca/build/utils/color";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { textColorForBackground } from "@hyperledger/aries-oca/build/utils/color";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 import { CredentialExchangeRecord } from "@aries-framework/core";
 import { useMemo, useState } from "react";
 import {
   CredentialFormatter,
   DisplayAttribute,
   LocalizedCredential,
-} from "@aries-bifold/oca/build/formatters/Credential";
+} from "@hyperledger/aries-oca/build/formatters/Credential";
 import AttributeValue from "./AttributeValue";
 import AttributeLabel from "./AttributeLabel";
 

--- a/OCAExplorer/src/components/Form.tsx
+++ b/OCAExplorer/src/components/Form.tsx
@@ -12,7 +12,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 import OverlayBundleFactory from "../services/OverlayBundleFactory";
 import { Clear, UploadFile } from "@mui/icons-material";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 
 const BUNDLE_LIST_URL =
   "https://raw.githubusercontent.com/bcgov/aries-oca-bundles/main";

--- a/OCAExplorer/src/components/OverlayBrandingForm.tsx
+++ b/OCAExplorer/src/components/OverlayBrandingForm.tsx
@@ -16,7 +16,7 @@ import {
 } from "../contexts/Branding";
 import { saveAs } from "file-saver";
 import BrandingOverlayDataFactory from "../services/OverlayBrandingDataFactory";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 import ImageField from "./ImageField";
 
 function OverlayBrandingForm({

--- a/OCAExplorer/src/components/OverlayForm.tsx
+++ b/OCAExplorer/src/components/OverlayForm.tsx
@@ -16,7 +16,7 @@ import { BrandingProvider } from "../contexts/Branding";
 import CredentialCard from "./CredentialCard";
 import CredentialDetail from "./CredentialDetail";
 import OverlayBrandingForm from "./OverlayBrandingForm";
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
 
 import { Info } from "@mui/icons-material";
 import { CredentialExchangeRecord } from "@aries-framework/core";

--- a/OCAExplorer/src/services/OverlayBrandingDataFactory.ts
+++ b/OCAExplorer/src/services/OverlayBrandingDataFactory.ts
@@ -1,4 +1,4 @@
-import { IBrandingOverlayData } from "@aries-bifold/oca/build/interfaces/data";
+import { IBrandingOverlayData } from "@hyperledger/aries-oca/build/interfaces/data";
 import { BrandingState } from "../contexts/Branding";
 
 class BrandingOverlayDataFactory {

--- a/OCAExplorer/src/services/OverlayBundleFactory.ts
+++ b/OCAExplorer/src/services/OverlayBundleFactory.ts
@@ -1,5 +1,5 @@
-import { OverlayBundle } from "@aries-bifold/oca/build/types";
-import { IOverlayBundleData } from "@aries-bifold/oca/build/interfaces/data";
+import { OverlayBundle } from "@hyperledger/aries-oca/build/types";
+import { IOverlayBundleData } from "@hyperledger/aries-oca/build/interfaces/data";
 import { parse } from "csv-parse/browser/esm/sync";
 
 class OverlayBundleFactory {

--- a/OCAExplorer/yarn.lock
+++ b/OCAExplorer/yarn.lock
@@ -7,11 +7,6 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
-"@aries-bifold/oca@file:../aries-bifold/packages/oca":
-  version "1.0.0-alpha.0"
-  dependencies:
-    "@aries-framework/core" "^0.3.3"
-
 "@aries-framework/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.3.3.tgz#7bb097366bef8f53225785881376d56311edaf83"
@@ -423,6 +418,13 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@hyperledger/aries-oca@^1.0.0-alpha.7":
+  version "1.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@hyperledger/aries-oca/-/aries-oca-1.0.0-alpha.7.tgz#4ad3eb6d13baf3bf652632fb6dfba32ab652bfbb"
+  integrity sha512-qNCmlpeVKJTxHxW7pPTg4pP+bba5jL9i42vOVQ/7n+gIesBBfsS3FZDO5UH0k8v+GkiSJGx2kSJcwMhD3AXhqQ==
+  dependencies:
+    "@aries-framework/core" "^0.3.3"
 
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"


### PR DESCRIPTION
This PR, removes `aries-bifold` as a submodule in favour of the published NPM package. This should clean things up a bit.