### PR TITLE
Removed the "Are you sure you to use this file?" from the upload error

### DIFF
--- a/OCAExplorer/src/components/ImageField.tsx
+++ b/OCAExplorer/src/components/ImageField.tsx
@@ -110,8 +110,7 @@ export default function ImageField({
           ? errorMessage(
               <div>
                 ERROR: We recommend not using an image larger than{" "}
-                {MAX_IMAGE_SIZE} characters after encoding. Are you sure you
-                want to use this file?
+                {MAX_IMAGE_SIZE} characters after encoding.
               </div>
             )
           : undefined}


### PR DESCRIPTION
This seems to have not been removed even though the override is not longer an option. It makes more sense to simply display the error and not ask if they would like to use the file. 