### PR TITLE
Enable gen bundle to work when branding file has large images

### DIFF
--- a/scripts/genBundle.sh
+++ b/scripts/genBundle.sh
@@ -92,9 +92,12 @@ CAPTUREBASEITEM=$(grep -m 1 '"capture_base": "' ${OCABUNDLE} )
 for file in ${JSONFiles}; do
     BCKFILE=$(basename ${file}).bck
     # Replace the existing "capture_base" JSON item with one from the Excel OCA output
-    sed "s#.*capture_base.:.*#${CAPTUREBASEITEM}#" ${file} >${BCKFILE}
+    # and remove the outer array, if present.
+    sed -e "s#.*capture_base.:.*#${CAPTUREBASEITEM}#" \
+      -e '1,1 s/\[//' \
+      -e '$,$ s/]//' ${file} >${BCKFILE}
     # Add the overlay to the generated OCA Bundle and out to a temp file
-    ${JQ} ".[].overlays += $(cat ${BCKFILE})" ${OCABUNDLE} > ${TMPOCABUNDLE}
+    ${JQ} --slurpfile filejson ${BCKFILE} ".[].overlays += \$filejson" ${OCABUNDLE} > ${TMPOCABUNDLE}
     rm ${BCKFILE}
     # Move the tmp file to be the new(est) OCA Bundle file
     mv ${TMPOCABUNDLE} ${OCABUNDLE}


### PR DESCRIPTION
Fixes #100.  Bit of an ugly fix -- remove the outer array of the branding.json.  Would like to find a better way to do it in JQ language, but couldn't find anything.  This will work for how the instructions are given for branding.json and if there is no outer array in the branding.json file.
