### PR TITLE
Update the ocabundle.json generator to be more flexible about the locations of bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,22 @@ your needs!
 
 OCA Bundles in this repository are found in the [OCABundles](./OCABundles/)
 folder in this repository. The folder structure within `OCABundles` is as follows
-with OCABundle JSON files in the `<Credential>` and `<Schema>` folders.
+with OCABundle JSON files in the `<Bundle>` folders. The folders can be nested
+arbitrarily deeply, and the `<Bundle>` folder **MUST** have an `OCABundle.json`
+file that is the OCA Bundle itself, plus a `README.md` file that contains
+the structured information about the Bundle. More on that below.
 
 ```
 OCABundles
- ┣ credentials
- ┃ ┣ <Issuer>
- ┃ ┃ ┣ <Credential>
- ┃ ┃ ┗ <Credential>
- ┃ ┣ <Issuer>
- ┃ ┃ ┣ <Credential>
- ┃ ┃ ┗ <Credential>
  ┗ schema
- ┃ ┣ <Publisher>
- ┃ ┃ ┣ <Schema>
- ┃ ┃ ┗ <Schema>
- ┃ ┗ <Publisher>
- ┃ ┃ ┣ <Schema>
- ┃ ┃ ┗ <Schema>
+ ┃ ┣ <Issuer/Publisher>
+ ┃ ┃ ┣ <Bundle>
+ ┃ ┃ ┣ <Credential Type>
+ ┃ ┃ ┃ ┣ <Bundle>
+ ┃ ┃ ┃ ┗ <Bundle>
+ ┃ ┗ <Issuer/Publisher>
+ ┃ ┃ ┣ <Bundle>
+ ┃ ┃ ┗ <Bundle>
  ```
 
 ## Contributing an OCA Bundle
@@ -89,12 +87,13 @@ OCABundles
 To contribute an OCA Bundle, create a pull request that adds the necessary files
 for the Aries for OCA:
 
-* In the OCABundles `schema` or `credentials` folder, if needed, create a new
-`<Issuer>` or `<Publisher>`. Those folders are for organizing the credentials
+* In the OCABundles `schema` folder, if needed, create a new
+`<Issuer/Publisher>`. Those folders are for organizing the credentials
 and the folder naming is up to the submitter.
-* Within that folder, create another folder named for the schema or credential
-  definition being added.
-* Within that folder, add the following files, as appropriate:
+* Create additional folders below, named for the schema or credential
+  type being added. As needed, nest the folders as make sense. At leaf
+  must be the `<Bundle>` folder.
+* Within the `<Bundle>` folder, add the following files, as appropriate:
     * README.md: **MUST** be present and **MUST** contain the information outlined
       below in the [README File Content](#readme-file-content) section of this document.
     * OCABundle.json: **MUST** be present and **MUST** contain the OCA Bundle
@@ -114,9 +113,10 @@ process and merged (or not) into the repository.
 
 The README.md file for the OCA Bundle **MUST** be present and **MUST** include
 begin with the information shown and described below. The formatting requirements
-are in place because the file is processed by a script that generates a list
+are in place because the file is processed by a script that generates two lists
 of all of the identifiers (`schemaId`s and `credDefId`s) and the OCA Bundles
-to which they are associated with.
+to which they are associated with. The lists are in the files `ocbundles.json`
+and `ocabundleslist.json` in the root folder of the repository.
 
 ```text
 # <TITLE>
@@ -220,7 +220,7 @@ The wallet/agent may want to cache a loaded OCA Bundle.
 ### Processing Notes
 
 * A given Aries agent **MAY** want to pre-load OCA Bundles for Schemas or
-Credential Definitions all of the identifiers in the `ocabundles.json` file.
+Credential Definitions for all of the identifiers in the `ocabundles.json` file.
 From time-to-time, such agents may want to reload the Bundles in case they have
 been updated in the repository.
 

--- a/scripts/gen_ocabundlesjson.sh
+++ b/scripts/gen_ocabundlesjson.sh
@@ -1,27 +1,30 @@
 #!/bin/bash
 
-OCAIDSJSON=ocabundles.json
-OCALISTJSON=ocabundleslist.json
+OCAIDSJSON=${PWD}/ocabundles.json
+OCALISTJSON=${PWD}/ocabundleslist.json
+TMPFILE=${PWD}/tmpfile.json
+ROOTDIR=${PWD}
 
 # Usage info
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-h] -x EXCEL [JSON FILES]...
-Generate an OCA Bundle from an Excel file and optionally add
-zero or more JSON OCA overlays.
+Usage: gen_ocabundlesjson.sh
 
-    -h          display this help and exit
-    -x EXCEL    write the result to OUTFILE instead of standard output.
-    JSON FILES  one or more JSON files that are overlays to added to the OCA Bundle.
+Starting from the OCABundles folder in the current folder, and recurse through
+all the folders below. For each OCA Bundle found -- identified by the existance
+of a README.md file and an OCABundles.json file -- add the information about the
+Bundle to the "ocabundles.json" and "ocabundleslist.json" files. Those two files
+are generated in the current folder. The appropriate JSON header is put into the
+two files, the last entry of each file does not have a trailing ",", and an
+appropriate footer is put into the two files.
 
-The output from a successfule run of the script is always a file called "${OCABUNDLE}".
+The script exits with an error if the OCABundles folder is not in the current
+folder.
 
-Running this script requires access to the OCA Excel Parser executable,
-and the JQ (JSON Query) executable. See the instructions in the README
-for details on how to install them.    
 EOF
 }
 
+# Have to be sure we're in the root folder of the repository
 thisDir=${PWD}
 if [ ! -d "OCABundles" ]; then
     echo ERROR: There is no OCABundles folder. This script must be run from the root of the repository.
@@ -30,54 +33,61 @@ if [ ! -d "OCABundles" ]; then
     exit 1
 fi
 
+# In a folder with an OCABundle, process the file, and add the data for the bundle into the JSON files
+processBundle() {
+    RELPATH=$(echo ${PWD} | sed -e "s#${ROOTDIR}/##")
+    BUNDLE_PATH=OCABundle.json
+    SHASUM=$(shasum -a256 -U $BUNDLE_PATH | sed "s/ .*//")
+    ID=$(grep '^| ' README.md | sed -e "/OCA Bundle/,100d" -e "/Identifier/d" -e "/----/d" -e 's/^| \([^|]*\) |.*/\1/' -e 's/\s*$//' -e 's/ /~/g')
+    for id in ${ID}; do
+        echo "\"${id}\": { \"path\": \"${RELPATH}/${BUNDLE_PATH}\" }," | sed "s/~/ /g" >>${OCAIDSJSON}
+        # Use the line below if we want to add a SHA256 item to the JSON list, for checking if the bundle has changed
+        # echo "   \"${id}\": { \"path\": \"${RELPATH}/${BUNDLE_PATH}\", \"sha256\": \"${SHASUM}\" }," | sed "s/~/ /g" >>${OCAIDSJSON}
+    done
+    ORG=$(grep "Publishing\|Issuing" README.md | sed -e "s/.*: //")
+    NAME=$(sed -e "2,1000d" -e "s/# //" README.md)
+    DESC=$(sed -e "1,2d" -e "/## Identifiers/,1000d" -e "/^\s*$/d" -e "/^- /d" -e 's/[][]//g' -e 's/(.*)//g' -e 's/"/\\"/g' README.md)
+    TYPE="schema"
+    if [ "$(echo ${PWD} | grep "schema")" == "" ]; then
+        TYPE="credential"
+    fi
+    echo "{ \"org\": \"${ORG}\", \"name\": \"${NAME}\", \"desc\": \"${DESC}\", \"type\": \"${TYPE}\", \"ocabundle\": \"${RELPATH}/${BUNDLE_PATH}\" }," >>${OCALISTJSON}
+    # Use the line below if we want to add a SHA256 item to the JSON list, for checking if the bundle has changed
+    # echo "{ \"org\": \"${ORG}\", \"name\": \"${NAME}\", \"desc\": \"${DESC}\", \"type\": \"${TYPE}\", \"ocabundle\": \"${RELPATH}/${BUNDLE_PATH}\", \"shasum\": \"${SHASUM}\" }," >>${OCALISTJSON}
+}
+
+# Recursively process the folders
+processFolder() {
+    # If the right files are in the folder, process it
+    if [[ -f README.md && -f OCABundle.json ]]; then
+      processBundle README.md OCABundle.json
+    fi
+    # Recurse into the directories of the folder
+    for dir in *; do
+        if [ -d $dir ]; then
+            cd $dir
+            processFolder
+            cd ..
+        fi
+    done
+}
+
+
 # Write the headers for the files
 echo -e "{" >${OCAIDSJSON}
 echo -e "[" >${OCALISTJSON}
 
-declare -a schema_files
-schema_files=(OCABundles/schema/*)
-last_schema_idx=$(( ${#schema_files[*]} - 1 ))
-curr_schema_idx=0
-for i in OCABundles/schema/*; do
-    last_schema=false
-    if [[ $curr_schema_idx -eq $last_schema_idx ]]; then
-        last_schema=true
-    fi
-    if [ -d "${i}" ]; then
-        declare -a files
-        files=(${i}/*)
-        last_idx=$(( ${#files[*]} - 1 ))
-        curr_idx=0
-        for j in ${i}/*; do
-            BUNDLE_PATH=${j}/OCABundle.json
-            ID=$(grep '^| ' ${j}/README.md | sed -e "/OCA Bundle/,100d" -e "/Identifier/d" -e "/----/d" -e 's/^| \([^|]*\) |.*/\1/' -e 's/\s*$//' -e 's/ /~/g')
-            last_id_idx=$(( ${#ID[*]} - 1 ))
-            curr_id_idx=0
-            for id in ${ID}; do
-                delim=","
-                if [[ $last_schema = true && $curr_idx -eq $last_idx ]]; then
-                    delim=""
-                fi
-                echo "\"${id}\": { \"path\": \"${BUNDLE_PATH}\" }${delim}" | sed "s/~/ /g" >>${OCAIDSJSON}
-                curr_id_idx=$(( $curr_id_idx + 1))
-            done
-            ORG=$(grep "Publishing\|Issuing" ${j}/README.md | sed -e "s/.*: //")
-            NAME=$(sed -e "2,1000d" -e "s/# //" ${j}/README.md)
-            DESC=$(sed -e "1,2d" -e "/## Identifiers/,1000d" -e "/^\s*$/d" -e "/^- /d" -e 's/[][]//g' -e 's/(.*)//g' -e 's/"/\\"/g' ${j}/README.md)
-            TYPE="schema"
-            if [ "$(echo ${j} | grep "schema")" == "" ]; then
-                TYPE="credential"
-            fi
-            delim=","
-            if [[ $last_schema = true && $curr_idx -eq $last_idx ]]; then
-                delim=""
-            fi
-            echo "{ \"org\": \"${ORG}\", \"name\": \"${NAME}\", \"desc\": \"${DESC}\", \"type\": \"${TYPE}\", \"ocabundle\": \"${BUNDLE_PATH}\" }${delim}" >>${OCALISTJSON}
-            curr_idx=$(( $curr_idx + 1))
-        done
-    fi
-    curr_schema_idx=$(( $curr_schema_idx + 1))
-done
+# Start in the OCABundles folder
+cd OCABundles
 
+# Recursively process the folders
+processFolder
+cd ..
+
+# Remove the trailing "," on the last generated line, so the JSON is properly formed
+sed -e '$s/.$//' ${OCAIDSJSON} >$TMPFILE; mv ${TMPFILE} ${OCAIDSJSON}
+sed -e '$s/.$//' ${OCALISTJSON} >$TMPFILE; mv ${TMPFILE} ${OCALISTJSON}
+
+# Write the footers for the files
 echo -e "}" >>${OCAIDSJSON}
 echo -e "]" >>${OCALISTJSON}


### PR DESCRIPTION
Addresses issue #99 -- allowing flexibility in the location of OCA Bundles in the repo.  The bundles **MUST** be under the OCABundles folder in the repo, but any folder found with an `OCABundle.json` and `README.md` is assumed to be a bundle and processed.  This allows, for example, the `mines-permit-act` to be a folder, and then multiple versions of the bundle (for example, `0.3` AND `1.1.1`) to be put below that.  Similar adjustments can be made for the various `person` credential versions -- the production, showcase and unverified person ones.

Updates/simplifies the script and updates the readme.
