### PR TITLE
move gh pages specifics to separate branch with action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,23 @@
+name: "Generate gen_ocabundlesjson.sh from main and publch to gh-pages branch"
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+jobs:
+  generateJson:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: run gen_ocabundlesjson.sh
+        run: ./scripts/gen_ocabundlesjson.sh
+      - name: push
+        uses: actions-x/commit@v6
+        with:
+          email: jasyrotuck@gmail.com
+          name: GitHub Actions Autocommitter
+          message: generate ocabundleslist.json
+          branch: gh-pages
+          files: ocabundleslist.json

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["gh-pages"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
New flow:
1. When main is updated, run GHA to generate additional files and update `gh-pages` branch. 
1. Migrate existing gh pages action to target new branch. 

Then  in the future we can remove generated file from main branch as they are not part of the code, just an artifact for the Explorer. 

Having trouble with unix style file permissions on my windows development machine to use `act`  and run it locally. 

First look at #90 